### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "biopython==1.85",
+    "biopython>=1.80",
     "numpy>=1.21",
     "pandas>=1.3.5",
     "plotly==5.24.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "biopython>=1.80",
+    "biopython==1.85",
     "numpy>=1.21",
     "pandas>=1.3.5",
     "plotly==5.24.0",

--- a/src/pycirclizely/__init__.py
+++ b/src/pycirclizely/__init__.py
@@ -1,6 +1,6 @@
 from pycirclizely.circos import Circos
 
-__version__ = "0.1.1"
+__version__ = "1.0.0"
 
 __all__ = [
     "Circos",


### PR DESCRIPTION
## v0.1.0 - First Release

This is the first release of pyCirclizely, a fork of pyCirclize with Plotly integration.  

### Features  

- Implemented Plotly support for virtually all plot types, with the exception of raster.  
- Added hover text functionalities, a key advantatge of plotly vs matplotlib.  

### Installation

`Python 3.10 or later` is required for installation.

**Install PyPI package:**

```
pip install pycirclizely
```

**Install conda-forge package:**

```
conda install -c conda-forge pycirclizely
```